### PR TITLE
v3

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,0 +1,15 @@
+# `3.0.0` (23 June 2016)
+
+small (but still breaking) changes made while writing [`inu-plays-roguelike`](https://github.com/ahdinosaur/inu-plays-roguelike):
+
+- [rename `streams` returned by `start` to `sources`](https://github.com/ahdinosaur/inu/commit/4faecd8b9fdb34a8ec60a22f1c3fa93e2ceaae67)
+- [`run` function receives all sources streams](https://github.com/ahdinosaur/inu/commit/f339622b12e39fd1ee15084cdbe8b76f85813688)
+- [replay last value for 'state-ful' sources](https://github.com/ahdinosaur/inu/commit/5e88de8b06bfab585eab5e960d3559242c5a4ee6)
+
+# `2.0.0` (13 May 2016)
+
+due to difficult in writing `./examples/compose.js` with `push-stream`, re-write using [`pull-stream`](https://pull-stream.github.io), thanks to [`pull-notify`](https://pull-stream.github.io/#pull-notify).
+
+# `1.0.0` (12 May 2016)
+
+more or less a direct port of [`gcanti/tom`](https://github.com/gcanti/tom) using [`push-stream`](https://github.com/ahdinosaur/push-stream) instead of [`rx`](https://www.npmjs.com/package/rx)

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ streams is an object with the following keys:
 - `models`: a function that returns a [pull source stream](https://pull-stream.github.io) for models
 - `views`: a function that returns a [pull source stream](https://pull-stream.github.io) for views
 - `effects`: a function that returns a [pull source stream](https://pull-stream.github.io) for effects
-- `effectActionStreams`: a function that returns a [pull source stream](https://pull-stream.github.io) for any streams of next actions caused by effects
+- `effectActionsSources`: a function that returns a [pull source stream](https://pull-stream.github.io) for any streams of next actions caused by effects
 
 ![streams flow diagram](https://rawgit.com/ahdinosaur/inu/master/assets/flow-diagram.dot.svg)
 

--- a/README.md
+++ b/README.md
@@ -104,12 +104,15 @@ you can also require each module separately like `require('inu/start')`.
 streams is an object with the following keys:
 
 - `actions`: a function that returns a [pull source stream](https://pull-stream.github.io) for actions
-- `models`: a function that returns a [pull source stream](https://pull-stream.github.io) for models
-- `views`: a function that returns a [pull source stream](https://pull-stream.github.io) for views
-- `effects`: a function that returns a [pull source stream](https://pull-stream.github.io) for effects
+- `states`: a function that returns a state-ful\* [pull source stream](https://pull-stream.github.io) for states
+- `models`: a function that returns a state-ful\* [pull source stream](https://pull-stream.github.io) for models
+- `views`: a function that returns a state-ful\* [pull source stream](https://pull-stream.github.io) for views
+- `effects`: a function that returns a state-ful\* [pull source stream](https://pull-stream.github.io) for effects
 - `effectActionsSources`: a function that returns a [pull source stream](https://pull-stream.github.io) for any streams of next actions caused by effects
 
 ![streams flow diagram](https://rawgit.com/ahdinosaur/inu/master/assets/flow-diagram.dot.svg)
+
+\* in this context, *state-ful* means that the pull source stream will always start with the last value (if any) first.
 
 ### [`inu.html === require('yo-yo')`](https://github.com/maxogden/yo-yo)
 

--- a/assets/flow-diagram.dot
+++ b/assets/flow-diagram.dot
@@ -4,6 +4,6 @@ digraph app {
   states -> effects
   models -> views [label="view()"]
   views -> actions [label="dispatch()"]
-  effects -> effectActionStreams [label="run()"]
-  effectActionStreams -> actions
+  effects -> effectActionsSources [label="run()"]
+  effectActionsSources -> actions
 }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "dependencies": {
     "defined": "^1.0.0",
+    "pull-cat": "^1.1.9",
     "pull-notify": "^0.1.0",
     "pull-stream": "^3.3.2",
     "yo-yo": "^1.2.0"

--- a/start.js
+++ b/start.js
@@ -69,10 +69,20 @@ function start (app) {
   )
 
   var effectActionStreams = notify()
+
+  var streams = {
+    actions: actions.listen,
+    states: states.listen,
+    models: models.listen,
+    views: views.listen,
+    effects: effects.listen,
+    effectActionStreams: effectActionStreams.listen
+  }
+
   pull(
     effects.listen(),
     pull.map(function (effect) {
-      return run.call(app, effect, actions.listen)
+      return run.call(app, effect, streams)
     }),
     pull.filter(isNotNil),
     pull.drain(effectActionStreams)
@@ -87,15 +97,7 @@ function start (app) {
     states(initialState)
   })
 
-  return {
-    stop: stop,
-    actions: actions.listen,
-    states: states.listen,
-    models: models.listen,
-    views: views.listen,
-    effects: effects.listen,
-    effectActionStreams: effectActionStreams.listen
-  }
+  return Object.assign({}, streams, { stop: stop })
 
   function stop () {
     ;[

--- a/test/defaults.js
+++ b/test/defaults.js
@@ -25,7 +25,7 @@ test('defaultUpdate', function (t) {
     model: expectedModel,
     effect: 'INITIALIZE'
   }
-  var streams = inu.start({
+  var sources = inu.start({
     init: function () { return initialState },
     run: function (effect) {
       t.equal(effect, initialState.effect, 'effect received')
@@ -35,7 +35,7 @@ test('defaultUpdate', function (t) {
     }
   })
   pull(
-    streams.models(),
+    sources.models(),
     pull.drain(function (model) {
       t.equal(model, expectedModel, 'initial model is expected')
       process.nextTick(function () {
@@ -47,9 +47,9 @@ test('defaultUpdate', function (t) {
 })
 
 test('defaultView', function (t) {
-  var streams = inu.start({})
+  var sources = inu.start({})
   pull(
-    streams.views(),
+    sources.views(),
     pull.drain(function (view) {
       t.notOk(true, 'did not expect to receive default empty view')
     })
@@ -70,14 +70,14 @@ test('defaultRun', function (t) {
     model: true,
     effect: 'INITIALIZE'
   }
-  var streams = inu.start({
+  var sources = inu.start({
     init: function () { return initialState },
     view: function (model, dispatch) {
       expectedActions.forEach(dispatch)
     }
   })
   pull(
-    streams.actions(),
+    sources.actions(),
     pull.take(3),
     pull.collect(function (err, actions) {
       t.error(err)
@@ -88,7 +88,7 @@ test('defaultRun', function (t) {
 })
 
 test('defaultApp', function (t) {
-  var streams = inu.start()
-  t.ok(streams, 'undefined app has streams')
+  var sources = inu.start()
+  t.ok(sources, 'undefined app has sources')
   t.end()
 })

--- a/test/dispatch.js
+++ b/test/dispatch.js
@@ -57,8 +57,8 @@ test('Calling dispatch emits actions on the action stream.', function (t) {
       return inu.html`<div></div>`
     }
   }
-  var streams = inu.start(app)
-  pull(streams.actions(), pull.take(1), pull.drain(function (action) {
+  var sources = inu.start(app)
+  pull(sources.actions(), pull.take(1), pull.drain(function (action) {
     t.equal(action, expectedAction)
     t.end()
   }))

--- a/test/init.js
+++ b/test/init.js
@@ -46,3 +46,38 @@ test('returning an effect in init emits the effect on the effects stream', funct
     t.end()
   }))
 })
+
+test('stateful sources pool last value', function (t) {
+  var app = {
+    init: function () {
+      return {
+        model: 'model',
+        effect: 'effect'
+      }
+    },
+    update: function (model, action) {
+      return {model: model}
+    },
+    view: function (model, dispatch) {
+      dispatch()
+      return inu.html`<div></div>`
+    },
+    run: function () {}
+  }
+  var sources = inu.start(app)
+  t.plan(4)
+  process.nextTick(function () {
+    pull(sources.states(), pull.take(1), pull.drain(function (model) {
+      t.deepEqual(model, { model: 'model', effect: 'effect' })
+    }))
+    pull(sources.models(), pull.take(1), pull.drain(function (model) {
+      t.equal(model, 'model')
+    }))
+    pull(sources.effects(), pull.take(1), pull.drain(function (effect) {
+      t.equal(effect, 'effect')
+    }))
+    pull(sources.views(), pull.take(1), pull.drain(function (view) {
+      t.equal(view.toString(), '<div></div>')
+    }))
+  })
+})

--- a/test/init.js
+++ b/test/init.js
@@ -40,8 +40,8 @@ test('returning an effect in init emits the effect on the effects stream', funct
     },
     run: function () {}
   }
-  var streams = inu.start(app)
-  pull(streams.effects(), pull.take(1), pull.drain(function (effect) {
+  var sources = inu.start(app)
+  pull(sources.effects(), pull.take(1), pull.drain(function (effect) {
     t.equal(effect, expectedEffect)
     t.end()
   }))

--- a/test/run.js
+++ b/test/run.js
@@ -123,7 +123,8 @@ test('actions stream passed to run emits actions', function (t) {
     view: function (model, dispatch) {
       return inu.html`<div></div>`
     },
-    run: function (effect, actions) {
+    run: function (effect, streams) {
+      const actions = streams.actions
       pull(actions(), pull.take(1), pull.drain(function (action) {
         t.equal(action, expectedAction)
         t.end()

--- a/test/run.js
+++ b/test/run.js
@@ -99,8 +99,8 @@ test('returning an action from effect emits actions on the action stream.', func
       return pull.values([expectedAction])
     }
   }
-  var streams = inu.start(app)
-  pull(streams.actions(), pull.take(1), pull.drain(function (action) {
+  var sources = inu.start(app)
+  pull(sources.actions(), pull.take(1), pull.drain(function (action) {
     t.equal(action, expectedAction)
     t.end()
   }))
@@ -123,8 +123,8 @@ test('actions stream passed to run emits actions', function (t) {
     view: function (model, dispatch) {
       return inu.html`<div></div>`
     },
-    run: function (effect, streams) {
-      const actions = streams.actions
+    run: function (effect, sources) {
+      const actions = sources.actions
       pull(actions(), pull.take(1), pull.drain(function (action) {
         t.equal(action, expectedAction)
         t.end()

--- a/test/stop.js
+++ b/test/stop.js
@@ -18,13 +18,13 @@ test('calling stop() ends actions stream', function (t) {
       return inu.html`<div></div>`
     }
   }
-  var streams = inu.start(app)
-  pull(streams.actions(), pull.collect(function (err, actions) {
+  var sources = inu.start(app)
+  pull(sources.actions(), pull.collect(function (err, actions) {
     t.error(err)
     t.equal(actions.length, 0, 'Actions stream ends with no emitted actions')
     t.end()
   }))
-  streams.stop()
+  sources.stop()
 })
 
 test('calling stop() ends effects stream', function (t) {
@@ -42,13 +42,13 @@ test('calling stop() ends effects stream', function (t) {
       return inu.html`<div></div>`
     }
   }
-  var streams = inu.start(app)
-  pull(streams.effects(), pull.collect(function (err, effects) {
+  var sources = inu.start(app)
+  pull(sources.effects(), pull.collect(function (err, effects) {
     t.error(err)
     t.equal(effects.length, 0, 'Effects stream ends with no emitted actions')
     t.end()
   }))
-  streams.stop()
+  sources.stop()
 })
 
 test('calling stop() ends views stream', function (t) {
@@ -66,13 +66,13 @@ test('calling stop() ends views stream', function (t) {
       return inu.html`<div></div>`
     }
   }
-  var streams = inu.start(app)
-  pull(streams.views(), pull.collect(function (err, views) {
+  var sources = inu.start(app)
+  pull(sources.views(), pull.collect(function (err, views) {
     t.error(err)
     t.equal(views.length, 0, 'Views stream ends with no emitted actions')
     t.end()
   }))
-  streams.stop()
+  sources.stop()
 })
 
 test('calling stop() ends models stream', function (t) {
@@ -90,13 +90,13 @@ test('calling stop() ends models stream', function (t) {
       return inu.html`<div></div>`
     }
   }
-  var streams = inu.start(app)
-  pull(streams.models(), pull.collect(function (err, models) {
+  var sources = inu.start(app)
+  pull(sources.models(), pull.collect(function (err, models) {
     t.error(err)
     t.equal(models.length, 0, 'Models stream ends with no emitted actions')
     t.end()
   }))
-  streams.stop()
+  sources.stop()
 })
 test('calling stop() ends effectAction stream', function (t) {
   var initialModel = {initial: true}
@@ -113,11 +113,11 @@ test('calling stop() ends effectAction stream', function (t) {
       return inu.html`<div></div>`
     }
   }
-  var streams = inu.start(app)
-  pull(streams.effectActionStreams(), pull.collect(function (err, effectActions) {
+  var sources = inu.start(app)
+  pull(sources.effectActionsSources(), pull.collect(function (err, effectActions) {
     t.error(err)
     t.equal(effectActions.length, 0, 'EffectActions stream ends with no emitted actions')
     t.end()
   }))
-  streams.stop()
+  sources.stop()
 })

--- a/test/update.js
+++ b/test/update.js
@@ -18,9 +18,9 @@ test('models returned by update are emitted by the model stream', function (t) {
       return inu.html`<div></div>`
     }
   }
-  var streams = inu.start(app)
+  var sources = inu.start(app)
 
-  pull(streams.models(), pull.take(2), pull.collect(function (err, models) {
+  pull(sources.models(), pull.take(2), pull.collect(function (err, models) {
     t.error(err)
     t.equal(models[0], initialModel)
     t.equal(models[1], expectedModel)

--- a/test/view.js
+++ b/test/view.js
@@ -15,9 +15,9 @@ test('newly created app renders initial state', function (t) {
       return inu.html`<div></div>`
     }
   }
-  var streams = inu.start(app)
+  var sources = inu.start(app)
   pull(
-    streams.views(),
+    sources.views(),
     pull.drain(function (view) {
       t.ok(view)
       t.end()


### PR DESCRIPTION
oops https://github.com/ahdinosaur/inu/issues/20, continuation of https://github.com/ahdinosaur/inu/issues/19, here are the changes i've made writing [`inu-plays-roguelike`](https://github.com/ahdinosaur/inu-plays-roguelike`):

- rename ([`pull-notify`](https://github.com/pull-stream/pull-notify) `.listen`) `streams` returned by `start` to `sources`
- `run` function receives `sources` (as returned by `start`) instead of `actions`.
- ["state-ful" sources (states, models, effects, views) always start with the latest value first, regardless of when you start listening](https://github.com/ahdinosaur/inu/issues/19#issuecomment-226670145)