### PR TITLE
[minor] Th͏e Da҉rk Pońy Lo͘r͠d HE ́C͡OM̴E̸S

### DIFF
--- a/start.js
+++ b/start.js
@@ -30,9 +30,19 @@ function start (app) {
   var run = defined(app.run, defaults.run)
 
   var actions = notify()
+  var nextActions = notify()
+
+  pull(
+    nextActions.listen(),
+    drain(function (value) {
+      process.nextTick(function () {
+        actions(value)
+      })
+    })
+  )
 
   function dispatch (nextAction) {
-    actions(nextAction)
+    nextActions(nextAction)
   }
 
   var initialState = init.call(app)
@@ -83,7 +93,8 @@ function start (app) {
     models: models,
     views: views,
     effects: effects,
-    effectActionsSources: effectActionsSources
+    effectActionsSources: effectActionsSources,
+    nextActions: nextActions
   }
 
   var sources = {}
@@ -105,7 +116,7 @@ function start (app) {
 
   pull(
     effectActionsSources.listen(),
-    drainMany(actions)
+    drainMany(nextActions)
   )
 
   process.nextTick(function () {


### PR DESCRIPTION
delay actions until next tick to keep Zalgo away

- https://github.com/ahdinosaur/inu/issues/19#issuecomment-226185139
- https://github.com/gcanti/tom/commit/a0245f755b74e27c5b7a7116a014432666d960d1#commitcomment-17479754

use case is a route handler like

```js
['/', (params, model, dispatch) => {
  if (model.account) {
    dispatch(navigate('dashboard'))
  }

  return landingView(model, dispatch)
]
```

which causes an infinite loop. if i add a variable that ensures it only runs once, it works. with this change, it also works.

probably should test to make sure this is an actual bug, not just the heebie jeebies.